### PR TITLE
Update batch.cfn.yaml

### DIFF
--- a/source/code/cfn/core/batch.cfn.yaml
+++ b/source/code/cfn/core/batch.cfn.yaml
@@ -116,8 +116,8 @@ Resources:
             - chown -R ec2-user:ec2-user /opt/miniconda
             - rm Miniconda3-latest-Linux-x86_64.sh
 
-            - service docker start
-            - start ecs
+            - systemctl restart docker --no-block
+            - systemctl enable --now --no-block ecs.service
 
             --==BOUNDARY==--
 


### PR DESCRIPTION
according to https://docs.aws.amazon.com/AmazonECS/latest/developerguide/ecs-agent-install.html to avoid circular dependencies, quoting:
```
The systemd units for both ECS and Docker services have a directive to wait for cloud-init to finish before starting both services. The cloud-init process is not considered finished until your Amazon EC2 user data has finished running. Therefore, starting ECS or Docker via Amazon EC2 user data may cause a deadlock. To start the container agent using Amazon EC2 user data you can use systemctl enable --now --no-block ecs.service. 
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
