### PR TITLE
natgateway/* needs ec2:CreateTags permission

### DIFF
--- a/source/pipe/cfn/iam.cfn.yaml
+++ b/source/pipe/cfn/iam.cfn.yaml
@@ -123,6 +123,7 @@ Resources:
                   - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*
                   - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:vpc/*
                   - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:internet-gateway/*
+                  - !Sub arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:natgateway/*
               - Effect: Allow
                 Action:
                   - ec2:DeleteVpcEndpoints


### PR DESCRIPTION
natgateway/* needs ec2:CreateTags permission, otherwise source/code/cfn/core/networking.cfn.yaml stack will not be completed

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
